### PR TITLE
Fix compilation error + add new ntdll.dll entry

### DIFF
--- a/CacheSim/CacheSim.cpp
+++ b/CacheSim/CacheSim.cpp
@@ -827,6 +827,7 @@ bool CacheSimStartCapture()
     {
       { 0x1a9000, 0x1a875f, 101552 },   // Win 7 SP1 v6.1 build 7601
       { 0x1ac000, 0x1a7d5d, 351820 },   // Win 8.1 RTM
+      { 0x1ad000, 0x1aa28f, 351756 },   // Win 8.1 Pro build 9600
       { 0x1be000, 0x1cc294,  94928 },   // Win 8.0 RTM
       { 0x1d1000, 0x1d204f, 436668 },   // Win 10 1607 build 14393.222
       { 0x1d1000, 0x1dc01c, 441340 },   // Win 10 1607 build 14393.693

--- a/CacheSim/CacheSim.h
+++ b/CacheSim/CacheSim.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*! \file
 This DLL is loaded at runtime by the engine to perform cache simulation.
 As such there's no static binding to these functions, they're looked up with GetProcAddress().
-*/.
+*/
 
 #ifndef IG_CACHESIM_API
 #define IG_CACHESIM_API __declspec(dllimport)


### PR DESCRIPTION
@deplinenoise 
- The first commit fix a compilation error coming from a previously introduced '.'
- The second one adds a new definition for a ntdll.dll found in the wild
