### PR TITLE
Fix invalid memory access on string append

### DIFF
--- a/CacheSim/CacheSimLinux.cpp
+++ b/CacheSim/CacheSimLinux.cpp
@@ -26,6 +26,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Precompiled.h"
 
+#include <sched.h>
+#include <error.h>
+#include <errno.h>
+#include <time.h>
 #include <asm/prctl.h>
 #include <execinfo.h>
 #include <link.h>

--- a/Examples/ThreadedExample/ThreadedExample.cpp
+++ b/Examples/ThreadedExample/ThreadedExample.cpp
@@ -83,7 +83,8 @@ int main(int argc, char* argv[])
     int count = 0;
     while (run) {
       std::string s;
-      s.append("Hi!\n", count++);
+      s.append("Hi!\n");
+      count++;
       printf("%s %d\n", s.c_str(), count);
     }
     while (canExit == false) { std::this_thread::yield(); }


### PR DESCRIPTION
The ThreadedExample has an invalid memory acces problem:
You are calling ```std::string.append("Hi!\n, count++)``` which will call ```string& append (const char* s, size_t n);```[1] which is designed to pass char* + length.
Using ```count++``` will lead to segfaults after 4 iterations (in practice more) of the loop.

[1] [http://www.cplusplus.com/reference/string/string/append/](http://www.cplusplus.com/reference/string/string/append/)

modified:   Examples/ThreadedExample/ThreadedExample.cpp
called ```std::string::append(char*, size_t n)``` with loop iteration count ```n```
which lead to invalid memory access. Fixed by calling
```string::append(const string&)``` because the string is
known at compile time.