### PR TITLE
Make UI use C++14 explicitly

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -25,6 +25,8 @@
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
+set(CMAKE_CXX_STANDARD 14)
+
 set(moc_inputs
   CacheSimMainWindow.h
   CacheSimMainWindow.h


### PR DESCRIPTION
Fixes
```
/home/janisozaur/workspace/ig-cachesim/UI/TraceData.cpp: In member function ‘void CacheSim::TraceData::beginLoadTrace(QString)’:
/home/janisozaur/workspace/ig-cachesim/UI/TraceData.cpp:84:26: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QTimer::singleShot(0, [p = QPointer<TraceData>(this)]()
                          ^
/home/janisozaur/workspace/ig-cachesim/UI/TraceData.cpp: In member function ‘void CacheSim::TraceData::emitLoadFailure(QString)’:
/home/janisozaur/workspace/ig-cachesim/UI/TraceData.cpp:247:26: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QTimer::singleShot(0, [p = QPointer<TraceData>(this), msg = errorMessage]()
                          ^
/home/janisozaur/workspace/ig-cachesim/UI/TraceData.cpp:247:57: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QTimer::singleShot(0, [p = QPointer<TraceData>(this), msg = errorMessage]()
                                                         ^~~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp: In member function ‘void CacheSim::TraceTab::doCreateTreeView(QString, QString)’:
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:22: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                      ^~~~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:35: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                                   ^~~~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:50: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                                                  ^~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:81: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                                                                                 ^~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:90: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                                                                                          ^~~~~
/home/janisozaur/workspace/ig-cachesim/UI/TraceTab.cpp:209:105: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
   QtConcurrent::run([self = this, data = m_Data, tr = QThread::currentThread(), id = id, title = title, sym=rootSymbolOpt]()
                                                                                                         ^~~
```