### PR TITLE
Enlarge buffer for symbol resolver

### DIFF
--- a/UI/SymbolResolverLinux.cpp
+++ b/UI/SymbolResolverLinux.cpp
@@ -159,7 +159,7 @@ bool CacheSim::ResolveSymbols(const UnresolvedAddressData& input, QVector<Resolv
 
     // Figure out the actual file with the debug info. If there's anything in /usr/lib/debug, use that version instead
     // resolve any symlinks
-    char resolvedBaseFilename[1024];
+    char resolvedBaseFilename[PATH_MAX];
     if ( realpath(input.m_ModuleNames[moduleIndex].toLatin1().data(), resolvedBaseFilename) == nullptr )
     {
       strcpy(resolvedBaseFilename, input.m_ModuleNames[moduleIndex].toLatin1().data());


### PR DESCRIPTION
The `realpath` syscall requires the target buffer to be PATH_MAX
bytes-sized: https://man7.org/linux/man-pages/man3/realpath.3.html